### PR TITLE
Fix typescript exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "files": [
     "fonts",
     "svg",
-    "*.js"
+    "*.js",
+    "definitions.d.ts"
   ],
   "scripts": {
     "build": "npm run build:fonts && npm run build:js",


### PR DESCRIPTION
Correctly include the definitions typescript file in the files array of package.json